### PR TITLE
Wait until image exists.

### DIFF
--- a/src/light-stemcell-builder/driver/create_ami_driver.go
+++ b/src/light-stemcell-builder/driver/create_ami_driver.go
@@ -78,6 +78,14 @@ func (d *SDKCreateAmiDriver) Create(driverConfig resources.AmiDriverConfig) (res
 		return resources.Ami{}, errors.New("AMI id nil")
 	}
 
+	d.logger.Printf("waiting for AMI: %s to exist\n", *amiIDptr)
+	err = d.ec2Client.WaitUntilImageExists(&ec2.DescribeImagesInput{
+		ImageIds: []*string{amiIDptr},
+	})
+	if err != nil {
+		return resources.Ami{}, fmt.Errorf("waiting for AMI %s to exist: %s", *amiIDptr, err)
+	}
+
 	d.logger.Printf("waiting for AMI: %s to be available\n", *amiIDptr)
 	err = d.ec2Client.WaitUntilImageAvailable(&ec2.DescribeImagesInput{
 		ImageIds: []*string{amiIDptr},


### PR DESCRIPTION
More often than not, checking AMI availability immediately after registration throws an error--see the recent failing builds at https://ci.fr.cloud.gov/teams/main/pipelines/aws-light-stemcell-builder for examples. This patch waits until the AMI exists before waiting for it to be available.

@dlapiduz 